### PR TITLE
fix(hermes): allow egress to kube API server ClusterIP

### DIFF
--- a/k8s/applications/hermes.yaml
+++ b/k8s/applications/hermes.yaml
@@ -212,8 +212,15 @@ spec:
                 ports:
                   - protocol: TCP
                     port: 9377
-              # Kube API server
-              - ports:
+              # Kube API server. A port-only egress rule allows :443 to
+              # external/CIDR destinations but NOT to an in-cluster ClusterIP
+              # peer, so it never actually reached the API service at
+              # 10.96.0.1:443 (kubectl timed out). Select the API server
+              # ClusterIP explicitly via ipBlock so the agent's RBAC works.
+              - to:
+                  - ipBlock:
+                      cidr: 10.96.0.1/32
+                ports:
                   - protocol: TCP
                     port: 443
               # General HTTPS/HTTP egress (GitHub, GHCR, web tools)


### PR DESCRIPTION
## Problem
`kubectl` from inside the Hermes pod times out reaching the Kubernetes API server at `10.96.0.1:443` — despite the service account having cluster-wide `get/list/watch` (+ pod-delete) RBAC. Symptom: `kubectl get pods` hangs then fails with `dial tcp 10.96.0.1:443: i/o timeout`.

## Root cause
The NetworkPolicy egress had a **port-only** `:443` rule intended for the API server:
```yaml
# Kube API server
- ports:
    - protocol: TCP
      port: 443
```
A port-only egress rule (no `to:` peer) permits `:443` to **external/CIDR** destinations but does **not** reach an in-cluster **ClusterIP** peer. The API server is a ClusterIP service (`kubernetes.default.svc` → `10.96.0.1`), so its traffic was dropped.

This matches the observed selective failure: external HTTPS (GitHub, GHCR, web tools), DNS (:53), LiteLLM (:4000), and camofox (:9377) all worked — only the in-cluster API ClusterIP was unreachable.

## Fix
Give the API-server rule an explicit `to: ipBlock: 10.96.0.1/32` peer so the ClusterIP is actually selected:
```yaml
- to:
    - ipBlock:
        cidr: 10.96.0.1/32
  ports:
    - protocol: TCP
      port: 443
```
`10.96.0.1` is the resolved ClusterIP of `kubernetes.default.svc` in this cluster (confirmed from inside the pod).

## Note
The ClusterIP is hardcoded. If the service CIDR ever changes this rule must be updated; an alternative is a `kube-system` namespaceSelector on :443. The ipBlock is correct for the current cluster.

## Testing
After ArgoCD sync, from inside the hermes pod:
```
kubectl get pods -A
kubectl get pods -n <victoriametrics-ns>   # the original request that surfaced this
```
should succeed.